### PR TITLE
Use OIST v1.3.0 and verify images on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,9 @@ machine:
     version: 6
 
 deployment:
+
+  # Code to auto-generate image set manifest files
+  # for every commit to master
   production:
     branch: master
     commands:
@@ -15,12 +18,17 @@ deployment:
           git commit imageset.json -m 'Update image manifest [ci skip]';
           git push origin master;
         fi
+
+  # Code to publish images to S3 whenever a new
+  # GitHub release/tag is created
   publish-imageset:
     tag: /v.*/
     owner: Financial-Times
     commands:
       - ./node_modules/.bin/oist publish-s3 --bucket origami-imageset-data-eu --scheme specialisttitle --scheme-version $CIRCLE_TAG
       - ./node_modules/.bin/oist publish-s3 --bucket origami-imageset-data-us --scheme specialisttitle --scheme-version $CIRCLE_TAG
+
+# Test overrides, used to verify SVG images
 test:
   override:
-    - echo "no tests"
+    - ./node_modules/.bin/oist verify

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
     "node": "^6"
   },
   "devDependencies": {
-    "@financial-times/origami-image-set-tools": "^1.2.0"
+    "@financial-times/origami-image-set-tools": "^1.3.0"
   }
 }


### PR DESCRIPTION
This currently won't pass because some of the SVG images have `width` and `height` attributes. I avoided updating them here because I'm not confident it won't break for some users (and could do with talking through with one of you).