### PR TITLE
Use node LTS in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   # Publish the image set to S3
   publish:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:10
     steps:
       - checkout
       - run: git config --global user.email "origami.support@ft.com";


### PR DESCRIPTION
To hopefully avoid CI [errors](https://github.com/Financial-Times/origami-specialist-title-logos/runs/161872420).